### PR TITLE
Prevent possible race condition in Main Presenter by delaying credential publish

### DIFF
--- a/rxui-sample-java/src/main/java/com/artemzin/rxui/sample/java/MainPresenter.java
+++ b/rxui-sample-java/src/main/java/com/artemzin/rxui/sample/java/MainPresenter.java
@@ -59,7 +59,7 @@ class MainPresenter {
                 .switchMap(loginAndPassword -> authService.signIn(loginAndPassword.getValue0(), loginAndPassword.getValue1()).subscribeOn(ioScheduler)) // "API request".
                 .share();
 
-        credentials.connect();
+        subscription.add(credentials.connect());
 
         Observable<Success> signInSuccess = signInResult
                 .filter(it -> it instanceof Success)

--- a/rxui-sample-kotlin/src/main/kotlin/com/artemzin/rxui/sample/kotlin/MainPresenter.kt
+++ b/rxui-sample-kotlin/src/main/kotlin/com/artemzin/rxui/sample/kotlin/MainPresenter.kt
@@ -19,7 +19,7 @@ class MainPresenter(private val authService: AuthService, private val ioSchedule
         // Boolean is valid/invalid flag.
         val credentials = Observable
                 .combineLatest(login, password, { login, password -> Triple(login, password, login.isNotEmpty() && password.isNotEmpty()) })
-                .share()
+                .publish()
 
         subscription += credentials
                 .filter { it.third }
@@ -37,6 +37,8 @@ class MainPresenter(private val authService: AuthService, private val ioSchedule
                 .withLatestFrom(credentials, { click, credentials -> credentials.first to credentials.second })
                 .switchMap { authService.signIn(login = it.first, password = it.second).subscribeOn(ioScheduler) }
                 .share()
+
+        subscription += credentials.connect();
 
         subscription += signInResult
                 .filter { it is Success }


### PR DESCRIPTION
This is quite unlikely but it seems to me that by using share for the credentials observable, you risk a possible race condition where signInEnable, signInDisabled and signInResult could be fed different values.  
