### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Minimal implementation of [the concept of talking to Android View layer in a Reactive way described here](http://artemzin.com/blog/rxui-talking-to-android-view-layer-in-a-reactive-way/).
 
-#####RxUi [solves 3 main problems of communication](http://a.com) between Presenters/ViewModels/etc and View layer in Android applications:
+##### RxUi [solves 3 main problems of communication](http://a.com) between Presenters/ViewModels/etc and View layer in Android applications:
 
 1. `Main Thread` should be part of View layer, Presenters/ViewModels/etc should not know about it.
 2. Action posted to `Main Thread` should be part of `Subscription` so you could `unsubscribe()` it.
@@ -10,7 +10,7 @@ Minimal implementation of [the concept of talking to Android View layer in a Rea
 
 ---
 
-###Sample Apps
+### Sample Apps
 
 Check [Sample app written in Java](rxui-sample-java/src/main/java/com/artemzin/rxui/sample/java) and [Sample app written in Kotlin](rxui-sample-kotlin/src/main/kotlin/com/artemzin/rxui/sample/kotlin). 
 
@@ -18,7 +18,7 @@ Check [Sample app written in Java](rxui-sample-java/src/main/java/com/artemzin/r
 
 ---
 
-#####Basically, RxUi is just two main functions:
+##### Basically, RxUi is just two main functions:
 
 1. `bind(Observable<T>): Subscription`
 2. `ui(Action1<T>): Func1<Observable<T>, Subscription>`
@@ -38,9 +38,9 @@ interface SignInView {
 }
 ```
 
-####Download
+#### Download
 
-#####RxUi
+##### RxUi
 
 Only two functions at the moment: `RxUi.bind()` (use it in Presenters/ViewModels) and `RxUi.ui()` use it in `View` layer.
 
@@ -48,7 +48,7 @@ Only two functions at the moment: `RxUi.bind()` (use it in Presenters/ViewModels
 compile 'com.artemzin.rxui:rxui:1.0.1'
 ```
 &nbsp;
-#####RxUi Test
+##### RxUi Test
 
 Only one function at the moment: `TestRxUi.testUi()`, basically same as `RxUi.ui()` except that it's synchronous and does not know about Main Thread.
 
@@ -57,7 +57,7 @@ testCompile 'com.artemzin.rxui:rxui-test:1.0.1'
 ```
 
 &nbsp;
-#####RxUi Kotlin
+##### RxUi Kotlin
 
 Only one extension function at the moment: `Observable.bind()`, absolutely same as `RxUi.bind()` but easier to use in Kotlin.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
