### PR TITLE
Improve build speed by reusing computations from previous builds

### DIFF
--- a/ci/pull_request.sh
+++ b/ci/pull_request.sh
@@ -5,4 +5,4 @@ set -e
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 PROJECT_DIR=$DIR/..
 
-"$PROJECT_DIR"/gradlew -s clean build --no-daemon -p "$PROJECT_DIR"
+"$PROJECT_DIR"/gradlew -s clean build --daemon -p "$PROJECT_DIR"

--- a/ci/release.sh
+++ b/ci/release.sh
@@ -5,4 +5,4 @@ set -e
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 PROJECT_DIR=$DIR/..
 
-"$PROJECT_DIR"/gradlew -s clean build uploadArchives --info --no-daemon -p "$PROJECT_DIR"
+"$PROJECT_DIR"/gradlew -s clean build uploadArchives --info --daemon -p "$PROJECT_DIR"


### PR DESCRIPTION

[Gradle daemon](https://docs.gradle.org/current/userguide/gradle_daemon.html#header). The Daemon is a long-lived process that help to avoid the cost of JVM startup for every build. Since Gradle 3.0, Gradle daemon is enabled by default. For an older version, you should enable it by setting `org.gradle.daemon=true`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
